### PR TITLE
add more tests and clean type checking + parsing

### DIFF
--- a/src/fructose/type_parser.py
+++ b/src/fructose/type_parser.py
@@ -5,8 +5,7 @@ import dataclasses
 from collections.abc import Iterable, Mapping
 
 _primitive_types = set([int, str, float, bool])
-_old_wrapper_types = set([List, Dict, Tuple, Set])
-_new_wrapper_types = set([list, dict, tuple, set])
+_wrapper_types = set([list, dict])
 
 class InvalidTypeException(Exception):
     pass
@@ -14,61 +13,74 @@ class InvalidTypeException(Exception):
 class EmptyReturnException(Exception):
     pass
 
-def validate_return_type_for_function(func_name, return_type):
+### Validate the return signature of the function ###
 
+def validate_return_type_for_function(func_name, return_type):
+    """
+    Validates that the return type is supported by Fructose.
+    """
     if return_type is inspect.Signature.empty:
         raise EmptyReturnException(f"Return type for {func_name} is Empty. Please add a return type with this notation: def {func_name}(...) -> your_return_type:")
 
     if not is_supported_type(return_type):
-        raise NotImplementedError("Fructose does not support return type " + type_to_string(return_type) + " yet. Please use int, str, float, bool, or supported generic types.")
+        raise NotImplementedError("Fructose does not support return type " + type_to_string(return_type) + " yet. Please use int, str, float, bool, or generic types.")
+
 
 def is_supported_type(return_type):
+    """
+    Check if the return type is supported by Fructose.
+    The supported types are the primitive types & wrapper types and dataclasses.
+    """
+
     # Check if the return_type is directly one of the primitive types or a dataclass
     if return_type in _primitive_types or dataclasses.is_dataclass(return_type):
         return True
     
     # Determine the origin type for generic types or use the return_type itself for non-generic types
     origin = get_origin(return_type) or return_type
-    
-    if origin in _new_wrapper_types or origin in _old_wrapper_types:
-        # For generic types (those with __args__), ensure all argument types are supported
+
+    # Small hack to not support the typing module, better to catch it here than to let users do the LLM call
+    # and then get an error.
+    try:
+        if return_type.__module__ == "typing":
+            return False
+    except:
+        pass
+
+    # Check if the origin type is supported
+    if origin in _wrapper_types:
+        # Ensure all argument types for generic types are supported
         args = get_args(return_type)
-        if args:  # If there are type arguments, check each
-            return all(is_supported_type(arg) for arg in args)
-        else:  # For non-generic types (no __args__), treat as supported
-            return True
-    
+        return all(is_supported_type(arg) for arg in args) if args else True
+
     # If none of the above conditions are met, the type is not supported
     return False
 
+### Validate the that the return from the LLM is a valid type ###
 
-def type_to_string(my_type):
-    if not type(my_type) in [type, types.GenericAlias]:
-        raise InvalidTypeException(f"Invalid type: {my_type}")
+def perform_type_validation(value: Any, expected_type: Any):
+    """
+    Validates that the output of the LLM is a valid type and the one expected by the decorated function.
+    """
 
-    prefix = my_type.__name__
+    # validate container types
+    if get_origin(expected_type) or expected_type in _wrapper_types:
+        validate_container_type(value, expected_type)
+
+    # primitive types and dataclasses are validated directly 
+    elif expected_type in _primitive_types or dataclasses.is_dataclass(expected_type):
+        if not isinstance(value, expected_type):
+            raise ValueError(f"Expected value of type {expected_type}, but got type {type(value)}")
     
-    if hasattr(my_type, "__args__"):
-        args = getattr(my_type, "__args__")
-        formatted_args = [type_to_string(arg) for arg in args]
-        return f"{prefix}[{', '.join(formatted_args)}]"
     else:
-        return prefix
-
-def describe_dataclass_as_dict(cls) -> dict:
-    if not dataclasses.is_dataclass(cls):
-        raise ValueError(f"{cls.__name__} is not a dataclass.")
-    
-    type_hints = get_type_hints(cls)
-    
-    description = {}
-    for field in dataclasses.fields(cls):
-        field_type = type_hints[field.name]
-        description[field.name] = str(field_type.__name__)
-    
-    return description
+        raise NotImplementedError(f"Type validation for {expected_type} is not implemented.")
 
 def validate_container_type(value: Any, expected_type: Any):
+    """
+    Validates that container types have the correct type for their elements.
+    If a type isn't specified for the internal elements, it will just check that outer container type is correct.
+    """
+
     # Determine the origin of the expected type and its arguments
     expected_origin = get_origin(expected_type)
     expected_args = get_args(expected_type)
@@ -93,3 +105,32 @@ def validate_container_type(value: Any, expected_type: Any):
         # Ensure the value matches the expected container type
         if not isinstance(value, expected_origin):
             raise ValueError(f"Type cast failed, value {value} is not of expected container type {expected_origin}")
+
+
+### Helpers
+
+def describe_dataclass_as_dict(cls) -> dict:
+    if not dataclasses.is_dataclass(cls):
+        raise ValueError(f"{cls.__name__} is not a dataclass.")
+    
+    type_hints = get_type_hints(cls)
+    
+    description = {}
+    for field in dataclasses.fields(cls):
+        field_type = type_hints[field.name]
+        description[field.name] = str(field_type.__name__)
+    
+    return description
+
+def type_to_string(my_type):
+    if not type(my_type) in [type, types.GenericAlias]:
+        raise InvalidTypeException(f"Invalid type: {my_type}")
+
+    prefix = my_type.__name__
+    
+    if hasattr(my_type, "__args__"):
+        args = getattr(my_type, "__args__")
+        formatted_args = [type_to_string(arg) for arg in args]
+        return f"{prefix}[{', '.join(formatted_args)}]"
+    else:
+        return prefix

--- a/tests/test_ai_parse_result.py
+++ b/tests/test_ai_parse_result.py
@@ -1,0 +1,29 @@
+from fructose import Fructose
+from dataclasses import dataclass
+
+ai = Fructose()
+
+def test_parse_llm_result():
+
+    # primitive success cases
+    assert ai._parse_llm_result('{"final_response": "Hello, world!"}', str) == "Hello, world!"
+    assert ai._parse_llm_result('{"final_response": 42}', int) == 42
+    assert ai._parse_llm_result('{"final_response": 3.14}', float) == 3.14
+    assert ai._parse_llm_result('{"final_response": true}', bool) == True
+    assert ai._parse_llm_result('{"final_response": false}', bool) == False
+
+    # generic success cases
+    assert ai._parse_llm_result('{"final_response": [1, 2, 3]}', list) == [1, 2, 3]
+    assert ai._parse_llm_result('{"final_response": [1, 2, 3]}', list[int]) == [1, 2, 3]
+    assert ai._parse_llm_result("{\"final_response\": {\"a\": 1, \"b\": 2}}", dict[str, int]) == {"a": 1, "b": 2}
+
+    # dataclass success cases
+    @dataclass
+    class MyDataclass:
+        a: int
+        b: int
+
+    assert ai._parse_llm_result('{\"final_response\": {\"a\": 1, \"b\": 2}}', MyDataclass) == MyDataclass(a=1, b=2)
+
+    # edge cases -- especially "False" with a capital F is a common failure case
+    assert ai._parse_llm_result('{"final_response": "False"}', bool) == False

--- a/tests/test_type_parser.py
+++ b/tests/test_type_parser.py
@@ -1,3 +1,5 @@
+from typing import List
+from dataclasses import dataclass
 from fructose import type_parser
 
 def test_to_string():
@@ -17,3 +19,40 @@ def test_to_string():
 
     # combine all
     assert type_parser.type_to_string(dict[str, list[tuple[str, int]]]) == 'dict[str, list[tuple[str, int]]]'
+
+def test_supported_types():
+
+    # support for primitive types
+    assert type_parser.is_supported_type(int) == True
+    assert type_parser.is_supported_type(str) == True
+    assert type_parser.is_supported_type(float) == True
+    assert type_parser.is_supported_type(bool) == True
+
+    # support for generic types
+    assert type_parser.is_supported_type(list[int]) == True
+    assert type_parser.is_supported_type(list) == True
+    assert type_parser.is_supported_type(list[list[int]]) == True
+    assert type_parser.is_supported_type(dict[str, int]) == True
+
+    # support for dataclass
+    @dataclass
+    class Person:
+        pass
+    
+    assert type_parser.is_supported_type(Person) == True
+    assert type_parser.is_supported_type(list[Person]) == True
+
+    # not supported types
+    assert type_parser.is_supported_type(type(None)) == False
+    assert type_parser.is_supported_type(list[object]) == False
+    assert type_parser.is_supported_type(list[None]) == False
+    assert type_parser.is_supported_type(List) == False
+    assert type_parser.is_supported_type(List[str]) == False
+
+    # tuples and sets are not supported yet
+    assert type_parser.is_supported_type(set[str]) == False
+    assert type_parser.is_supported_type(tuple[str, int]) == False
+    assert type_parser.is_supported_type(tuple[str, int, float]) == False
+
+
+    


### PR DESCRIPTION
- more tests
- simplified the type checking logic
- more clear about not support the typing List, Dict etc.
- don’t support (yet!) tuple & set since they don’t have an obvious representation in json, these probably didn't work in the first place but we didn't have tests so probably didn't notice.

All tests pass & eval 100%
<img width="712" alt="Screenshot 2024-02-07 at 14 15 38" src="https://github.com/bananaml/fructose/assets/24875419/7d7a1719-99f9-4bb8-b4b8-cb5b1c7ad7a2">

<img width="917" alt="Screenshot 2024-02-07 at 14 13 25" src="https://github.com/bananaml/fructose/assets/24875419/9308b8bd-ffe0-4783-b0cb-0732542fcbd5">